### PR TITLE
Fix - keypress event to keydown changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Property      | Default  | Accepted values | Description
 ## Options
 Option      | Default  | Accepted values | Description
 ----------- | -------- | --------------- | -----------
-`useKbEvents`  | `false`  | `boolean`    | If true, the component will generate a `keypress` event and trigger it. If it returns with `false`, it won't insert the new character.
+`useKbEvents`  | `false`  | `boolean`    | If true, the component will generate a `keydown` event and trigger it. If it returns with `false`, it won't insert the new character.
 
 ## Built-in layouts
 * `normal` - Normal full layout. Similar as real keyboard layouts

--- a/src/keyboard.vue
+++ b/src/keyboard.vue
@@ -233,7 +233,7 @@
 					if (this.input.maxLength <= 0 || text.length < this.input.maxLength) {
 						if (this.options.useKbEvents) {
 							let e = document.createEvent("Event"); 
-							e.initEvent("keypress", true, true); 
+							e.initEvent("keydown", true, true);
 							e.which = e.keyCode = addChar.charCodeAt();
 							if (this.input.dispatchEvent(e)) {
 								text = this.insertChar(caret, text, addChar);


### PR DESCRIPTION
The keypress event does not work with recent versions of Chrome, I changed it to keydown event.